### PR TITLE
Add punctuation.accessor style

### DIFF
--- a/InspiredGitHub.tmTheme
+++ b/InspiredGitHub.tmTheme
@@ -230,6 +230,23 @@
             </dict>
 
             <!--
+                Operator Accessor
+            -->
+            <dict>
+                <key>name</key>
+                <string>Operator Accessor</string>
+                <key>scope</key>
+                <string>punctuation.accessor</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#a71d5d</string>
+                    <key>fontStyle</key>
+                    <string>bold</string>
+                </dict>
+            </dict>
+
+            <!--
                 Storage
             -->
             <dict>


### PR DESCRIPTION
Fix #9 

Updates the color of php object operator, among other things.

> Member access, scope resolution, or similar constructs should use the following scope. For Python or JavaScript this would be `.`. In PHP this would be applied to `->` and `::`. In C++, this would be applied to all three.

Source: [docs](https://www.sublimetext.com/docs/3/scope_naming.html#punctuation)